### PR TITLE
Make use of the general config section and split the parsers + test coverage

### DIFF
--- a/solgate/cli.py
+++ b/solgate/cli.py
@@ -48,7 +48,6 @@ def _transfer(ctx, key: str):
 
 
 @cli.command("list")
-@click.argument("newer-than", type=click.STRING)
 @click.option("-o", "--output", type=click.Path(exists=False), help="Output to a file instead of stdout.")
 @click.pass_context
 def _list(ctx, newer_than: str, output: str = None):
@@ -57,7 +56,7 @@ def _list(ctx, newer_than: str, output: str = None):
     Only files NEWER_THAN give value (added or modified) are listed.
     """
     try:
-        files = lookup(newer_than, ctx.obj["CONFIG_PATH"])
+        files = lookup(ctx.obj["CONFIG_PATH"])
         if output:
             serialize(files, output)
         else:

--- a/solgate/utils/__init__.py
+++ b/solgate/utils/__init__.py
@@ -2,6 +2,6 @@
 
 # flake8: noqa
 
-from .io import serialize, key_formatter
+from .io import key_formatter, read_general_config, serialize
 from .logging import logger
-from .s3 import S3FileSystem, S3File
+from .s3 import S3File, S3FileSystem

--- a/solgate/utils/io.py
+++ b/solgate/utils/io.py
@@ -3,11 +3,11 @@
 import json
 import re
 from configparser import ConfigParser, SectionProxy
-from datetime import datetime
 from dataclasses import dataclass
+from datetime import datetime
 from functools import lru_cache
 from string import Formatter
-from typing import Any, Iterator, Tuple, Union
+from typing import Any, Dict, Iterator, Tuple, Union
 
 DEFAULT_CONFIG_LOCATION = "/etc/solgate.ini"
 
@@ -50,14 +50,14 @@ def _convert_config_value(section: SectionProxy, key: str) -> Union[str, bool]:
         return section.get(key)
 
 
-def read_config(filename: str = None) -> Iterator[Tuple[str, dict]]:
+def _read_config(filename: str = None) -> ConfigParser:
     """Read INI file and parse values.
 
     Args:
-        filename (str): Config file location.
+        filename (str, optional): Configuration file location. Defaults to None.
 
-    Yields:
-        Iterator[Tuple[str, dict]]: Section name and content dict pair.
+    Returns:
+        ConfigParser: Pythonic representation of the config file.
 
     """
     filename = filename or DEFAULT_CONFIG_LOCATION
@@ -67,8 +67,42 @@ def read_config(filename: str = None) -> Iterator[Tuple[str, dict]]:
     if not config.sections():
         raise IOError(f"Invalid config file {filename}")
 
+    return config
+
+
+def read_s3_config(filename: str = None) -> Iterator[Tuple[str, dict]]:
+    """Read INI file and parse S3 clients related configuration.
+
+    Args:
+        filename (str, optional): Configuration file location. Defaults to None.
+
+    Yields:
+        Iterator[Tuple[str, dict]]: Section name and content dict pair.
+
+    """
+    config = _read_config(filename)
     for s in config.sections():
-        yield s, {k: _convert_config_value(config[s], k) for k in config[s].keys()}
+        if s.startswith("source_") or s.startswith("destination_"):
+            yield s, {k: _convert_config_value(config[s], k) for k in config[s].keys()}
+
+
+def read_general_config(filename: str = None) -> Dict[str, Any]:
+    """Read INI file and parse general configuration.
+
+    Args:
+        filename (str, optional): Configuration file location. Defaults to None.
+
+    Returns:
+        dict: General configuration section data.
+
+    """
+    config = _read_config(filename)
+    try:
+        section = config["solgate"]
+    except KeyError:
+        raise IOError(f"Invalid config file {filename}, missing 'solgate' section.")
+
+    return {k: _convert_config_value(section, k) for k in section.keys()}
 
 
 @dataclass

--- a/solgate/utils/io.py
+++ b/solgate/utils/io.py
@@ -9,6 +9,8 @@ from functools import lru_cache
 from string import Formatter
 from typing import Any, Iterator, Tuple, Union
 
+DEFAULT_CONFIG_LOCATION = "/etc/solgate.ini"
+
 
 class CustomEncoder(json.JSONEncoder):
     """JSON encoder that handles dates and iterations."""
@@ -48,7 +50,7 @@ def _convert_config_value(section: SectionProxy, key: str) -> Union[str, bool]:
         return section.get(key)
 
 
-def read_config(filename: str) -> Iterator[Tuple[str, dict]]:
+def read_config(filename: str = None) -> Iterator[Tuple[str, dict]]:
     """Read INI file and parse values.
 
     Args:
@@ -58,6 +60,7 @@ def read_config(filename: str) -> Iterator[Tuple[str, dict]]:
         Iterator[Tuple[str, dict]]: Section name and content dict pair.
 
     """
+    filename = filename or DEFAULT_CONFIG_LOCATION
     config = ConfigParser()
     config.read(filename)
 

--- a/solgate/utils/s3.py
+++ b/solgate/utils/s3.py
@@ -11,7 +11,7 @@ from botocore.exceptions import ClientError  # type: ignore
 from s3fs.errors import translate_boto_error  # type: ignore
 
 from .logging import logger
-from .io import read_config
+from .io import read_s3_config
 
 
 DEFAULT_ENDPOINTS = dict(source="https://s3.amazonaws.com/", destination="https://s3.upshift.redhat.com/")
@@ -42,7 +42,7 @@ class S3FileSystem:
 
         """
         self.name = name
-        self.is_source = bool(kwargs.pop("source", False))
+        self.is_source = name.lower().startswith("source_")
         self.endpoint_url = endpoint_url
         if not self.endpoint_url:
             self.endpoint_url = DEFAULT_ENDPOINTS["source"] if self.is_source else DEFAULT_ENDPOINTS["destination"]
@@ -69,11 +69,14 @@ class S3FileSystem:
 
         Create s3fs using credentials and paths from config files.
 
+        Args:
+            filename (str, optional): Configuration file location. Defaults to None.
+
         Returns:
             Iterable["S3FileSystem"]: S3 file system clients.
 
         """
-        config = read_config(filename)
+        config = read_s3_config(filename)
         clients = [cls(k, **v) for k, v in config]
 
         with_source_attribute = [*filter(lambda c: c.is_source, clients)]

--- a/solgate/utils/s3.py
+++ b/solgate/utils/s3.py
@@ -15,7 +15,6 @@ from .io import read_config
 
 
 DEFAULT_ENDPOINTS = dict(source="https://s3.amazonaws.com/", destination="https://s3.upshift.redhat.com/")
-CONFIG_FILE = "/etc/s3_settings.ini"
 
 
 class S3FileSystem:
@@ -74,7 +73,6 @@ class S3FileSystem:
             Iterable["S3FileSystem"]: S3 file system clients.
 
         """
-        filename = filename or CONFIG_FILE
         config = read_config(filename)
         clients = [cls(k, **v) for k, v in config]
 

--- a/tests/fixtures/sample_config.ini
+++ b/tests/fixtures/sample_config.ini
@@ -1,0 +1,34 @@
+[source_test]
+aws_access_key_id     = KEYID
+aws_secret_access_key = ACCESSKEY
+endpoint_url          = https://s3.upshift.redhat.com
+formatter             = {date}/{collection}.{ext}
+base_path             = DH-PLAYPEN/storage/input
+
+[destination_unpack_historic]
+aws_access_key_id     = KEYID
+aws_secret_access_key = ACCESSKEY
+endpoint_url          = https://s3.upshift.redhat.com
+formatter             = {collection}/historic/{date}-{collection}.{ext}
+base_path             = DH-PLAYPEN/storage/output
+unpack                = yes
+
+[destination_unpack_latest]
+aws_access_key_id     = KEYID
+aws_secret_access_key = ACCESSKEY
+endpoint_url          = https://s3.upshift.redhat.com
+formatter             = {collection}/latest/full_data.csv
+base_path             = DH-PLAYPEN/storage/output
+unpack                = yes
+
+[destination_raw]
+aws_access_key_id     = KEYID
+aws_secret_access_key = ACCESSKEY
+endpoint_url          = https://s3.upshift.redhat.com
+base_path             = DH-PLAYPEN/storage/output
+
+[solgate]
+alerts_smtp_server = smtp.corp.redhat.com
+alerts_from        = solgate-alerts@redhat.com
+alerts_to          = dev-null@redhat.com
+timedelta          = 6h

--- a/tests/utils/io_test.py
+++ b/tests/utils/io_test.py
@@ -101,3 +101,13 @@ def test__create_parser(mocker, formatter, regex):
     """Created parser's regex should match the pattern."""
     mocker.patch.object(io, "_get_param_names").return_value = set()
     assert io._create_parser(formatter).pattern.pattern == regex
+
+
+def test_read_config(mocker):
+    """Should parse config file."""
+    mocker.patch("builtins.open", mocker.mock_open(read_data="a"))
+
+    with open("x") as f:
+        print(f.read())
+
+    assert False

--- a/tests/utils/io_test.py
+++ b/tests/utils/io_test.py
@@ -1,7 +1,9 @@
 """Test suite for solgate/utils/io.py."""
-
 import datetime
+from pathlib import Path
+
 import pytest
+
 from solgate.utils import io
 
 
@@ -103,11 +105,70 @@ def test__create_parser(mocker, formatter, regex):
     assert io._create_parser(formatter).pattern.pattern == regex
 
 
-def test_read_config(mocker):
+@pytest.fixture(scope="session")
+def fixture_dir():
+    """Locate fixtures directory in the test folder."""
+    return Path(__file__).absolute().parent / ".." / "fixtures"
+
+
+def test__read_config(fixture_dir):
     """Should parse config file."""
-    mocker.patch("builtins.open", mocker.mock_open(read_data="a"))
+    config = io._read_config(fixture_dir / "sample_config.ini")
 
-    with open("x") as f:
-        print(f.read())
+    assert len(config.sections()) == 5
+    assert "solgate" in config.sections()
 
-    assert False
+
+def test__read_config_default_location(fixture_dir, mocker):
+    """Should read config from default location if no path is given."""
+    mocked_open = mocker.mock_open(read_data="[solgate]\n")
+    mocker.patch("builtins.open", mocked_open)
+    io._read_config()
+
+    mocked_open.assert_called_once()
+    assert mocked_open.call_args[0][0] == io.DEFAULT_CONFIG_LOCATION
+
+
+def test__read_config_empty(mocker):
+    """Should raise exception when config file is empty."""
+    mocked_open = mocker.mock_open()
+    mocker.patch("builtins.open", mocked_open)
+    with pytest.raises(EnvironmentError):
+        io._read_config()
+
+
+def test_read_s3_config(fixture_dir):
+    """Should parse s3 sections of the config."""
+    s3_sections = {k: v for k, v in io.read_s3_config(fixture_dir / "sample_config.ini")}
+
+    assert len(s3_sections.items()) == 4
+    assert "source_test" in s3_sections.keys()
+    assert sum([k.startswith("destination_") for k in s3_sections.keys()], 0) == 3
+
+    cred_keys = set(("aws_access_key_id", "aws_secret_access_key"))
+    assert all([cred_keys.issubset(v.keys()) for v in s3_sections.values()])
+
+
+def test_parse_booleans(mocker):
+    """Should properly parse boolean values."""
+    mocked_open = mocker.mock_open(read_data="[solgate]\ntrue_property = yes\nfalse_property = no")
+    mocker.patch("builtins.open", mocked_open)
+    section = io.read_general_config()
+
+    assert section["true_property"] is True
+    assert section["false_property"] is False
+
+
+def test_read_general_config(fixture_dir):
+    """Should parse s3 sections of the config."""
+    config = io.read_general_config(fixture_dir / "sample_config.ini")
+
+    assert len(config.items()) == 4
+
+
+def test_read_general_config_negative(mocker):
+    """Should raise exception when general section is missing from the config file."""
+    mocked_open = mocker.mock_open(read_data="[some]\nother = sections\n\n[but]\nnot = the\nones = we need")
+    mocker.patch("builtins.open", mocked_open)
+    with pytest.raises(EnvironmentError):
+        io.read_general_config()


### PR DESCRIPTION
## Related Issues and Dependencies

#1 

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Instead of one single parser, split it into 2 more distinct parsers:
1. For all the S3 related sections ( `source_*` and `destination_*`s )
2. For the general section `solgate`, that is now utilized for `timedelta` (will be used by the notification service as well)

Adding test coverage for all the config parsings. 