### PR TITLE
Set pipenv to not install prereleases

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-black = "*"
+black = "==19.10b0"
 mypy = "*"
 twine = "*"
 pytest = "*"
@@ -19,6 +19,3 @@ click = "*"
 
 [requires]
 python_version = "3.8"
-
-[pipenv]
-allow_prereleases = true

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7451195d36c1c932ac68d58cdc69e5426835d94d661cee68bbec346d774dcc3a"
+            "sha256": "64c6ab96a33f5178f04e70aa48a40aa0504a2a166ed98e31d81c7bb8ef04bdfb"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,10 +18,10 @@
     "default": {
         "botocore": {
             "hashes": [
-                "sha256:7c5c05ce8d785d442c93ee06694d03a9f6c34dca09bf48e6c13f6177261a6d36",
-                "sha256:82ef4a26cbc5a6197af43286b1895d220a8864c98c44f4c2e2f2e9bedecbce89"
+                "sha256:b869be5ca327bdf64d4e203f3bb6036cc9700e1cb55c8633779f74e0658d5d06",
+                "sha256:fd1c42436a4271fbcc8bc53357171ff01d9a1bea8efc4c8a00e58a531efdcb31"
             ],
-            "version": "==1.17.37"
+            "version": "==1.17.39"
         },
         "click": {
             "hashes": [


### PR DESCRIPTION
## Related Issues and Dependencies

Should suppress PRs like #12 and #8 

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

We had a `allow_prereleases = true` flag set in our `Pipfile` in order to install and maintain `black` dev package (which has no stable release what so ever). However this setting causes sesheta to look up other package's prereleases as well, and advertises them in a PR (like #12 or #8). That may cause troubles, because we may not want prereleased dependencies in the package environment. This PR locks `black` to its latest available version and removes the `allow_prerelease` flag from the config. 