### PR TITLE
aicoe-ci config file, to custom ci feature requirement

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -1,0 +1,5 @@
+check:
+  - thoth-build
+  - thoth-precommit
+release:
+  - upload-pypi-sesheta


### PR DESCRIPTION
aicoe-ci config file, to custom ci feature requirement:truck: aicoe-ci config file, to custom ci feature requirement
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-To: https://github.com/AICoE/aicoe-ci/issues/41

## This introduces a breaking change

- [x] No

## This Pull Request implements

- Added aicoe-ci configuration file, for allowing sync-pipeline maintainer to pick and choose aicoe-ci feature for sync-pipeline.

## Description

- Disabled pytest in aicoe-ci configuration file.
This feature would take effect once this PR is merged.