### PR TITLE
Build and publish using AICoE-CI

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -9,4 +9,4 @@ build:
   registry: quay.io
   registry-org: thoth-station
   registry-project: solgate
-  registry-secret: thoth-pusher
+  registry-secret: thoth-station-thoth-pusher-secret

--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -3,3 +3,10 @@ check:
   - thoth-precommit
 release:
   - upload-pypi-sesheta
+
+build:
+  base-image: registry.access.redhat.com/ubi8/python-38:latest
+  registry: quay.io
+  registry-org: thoth-station
+  registry-project: solgate
+  registry-secret: thoth-pusher


### PR DESCRIPTION
## Related Issues and Dependencies

Related to #22 
Resolves: #4 

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Use AICoE-CI to build and publish the Solgate image.
