### PR TITLE
Map solgate images to pull from quay.io

### DIFF
--- a/manifests/base/image-transformer-configuration.yaml
+++ b/manifests/base/image-transformer-configuration.yaml
@@ -1,0 +1,3 @@
+images:
+  - path: spec/templates[]/container/image
+    kind: WorkflowTemplate

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -8,3 +8,11 @@ resources:
   - ./webhook-gw.yaml
   - ./sensor.yaml
   - ./wftmpl.yaml
+
+configurations:
+  - image-transformer-configuration.yaml
+
+images:
+  - name: solgate
+    newName: quay.io/thoth-station/solgate
+    newTag: latest


### PR DESCRIPTION
## Related Issues and Dependencies

...

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Switch the manifests over to use the Quay.ion image of solgate built by AICoE-CI: https://quay.io/repository/thoth-station/solgate