### PR TITLE
Change default config location to a mountable dir for better Kubernetes support

### DIFF
--- a/manifests/base/wftmpl.yaml
+++ b/manifests/base/wftmpl.yaml
@@ -38,7 +38,7 @@ spec:
             memory: 100Mi
         volumeMounts:
           - name: config
-            mountPath: /etc/solgate.ini
+            mountPath: /etc/solgate
           - name: workdir
             mountPath: /mnt/vol
       volumes:
@@ -61,7 +61,7 @@ spec:
             memory: 100Mi
         volumeMounts:
           - name: config
-            mountPath: /etc/solgate.ini
+            mountPath: /etc/solgate
       volumes:
         - name: config
           secret:
@@ -86,7 +86,7 @@ spec:
             value: ""
         volumeMounts:
           - name: config
-            mountPath: /etc/solgate.ini
+            mountPath: /etc/solgate
       volumes:
         - name: config
           secret:

--- a/solgate/utils/io.py
+++ b/solgate/utils/io.py
@@ -9,7 +9,7 @@ from functools import lru_cache
 from string import Formatter
 from typing import Any, Dict, Iterator, Tuple, Union
 
-DEFAULT_CONFIG_LOCATION = "/etc/solgate.ini"
+DEFAULT_CONFIG_LOCATION = "/etc/solgate/config.ini"
 
 
 class CustomEncoder(json.JSONEncoder):


### PR DESCRIPTION
## Related Issues and Dependencies

…

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Kubernetes mounts secrets as whole folders, let's adjust our expected mount/config file location to this.