### PR TITLE
Allow section names without underscore

### DIFF
--- a/solgate/utils/io.py
+++ b/solgate/utils/io.py
@@ -96,7 +96,7 @@ def read_s3_config(filename: str = None) -> Iterator[Tuple[str, dict]]:
     """
     config = _read_config(filename)
     for s in config.sections():
-        if s.startswith("source_") or s.startswith("destination_"):
+        if s.startswith("source") or s.startswith("destination"):
             yield s, {k: _convert_config_value(config[s], k) for k in config[s].keys()}
 
 

--- a/solgate/utils/s3.py
+++ b/solgate/utils/s3.py
@@ -40,7 +40,7 @@ class S3FileSystem:
 
         """
         self.name = name
-        self.is_source = name.lower().startswith("source_")
+        self.is_source = name.lower().startswith("source")
         self.endpoint_url = endpoint_url
         if not self.endpoint_url:
             self.endpoint_url = DEFAULT_ENDPOINTS["source"] if self.is_source else DEFAULT_ENDPOINTS["destination"]

--- a/tests/fixtures/sample_config.ini
+++ b/tests/fixtures/sample_config.ini
@@ -1,4 +1,4 @@
-[source_test]
+[source]
 aws_access_key_id     = KEYID
 aws_secret_access_key = ACCESSKEY
 endpoint_url          = https://s3.upshift.redhat.com

--- a/tests/fixtures/single_destination.ini
+++ b/tests/fixtures/single_destination.ini
@@ -1,0 +1,18 @@
+[source]
+aws_access_key_id     = KEYID
+aws_secret_access_key = ACCESSKEY
+endpoint_url          = https://s3.upshift.redhat.com
+formatter             = {date}/{collection}.{ext}
+base_path             = DH-PLAYPEN/storage/input
+
+[destination]
+aws_access_key_id     = KEYID
+aws_secret_access_key = ACCESSKEY
+endpoint_url          = https://s3.upshift.redhat.com
+base_path             = DH-PLAYPEN/storage/output
+
+[solgate]
+alerts_smtp_server = smtp.corp.redhat.com
+alerts_from        = solgate-alerts@redhat.com
+alerts_to          = this-email-address-exists@redhat.com
+timedelta          = 6h

--- a/tests/transfer_test.py
+++ b/tests/transfer_test.py
@@ -49,7 +49,7 @@ def test_calc_s3_files(mocked_s3):
     gen = lambda: transfer.calc_s3_files("2020-01-01/collection_name.csv.gz", mocked_s3)  # noqa
 
     assert [(f.client.name, f.key) for f in gen()] == [
-        ("source_test", "2020-01-01/collection_name.csv.gz"),
+        ("source", "2020-01-01/collection_name.csv.gz"),
         ("destination_unpack_historic", "collection_name/historic/2020-01-01-collection_name.csv"),
         ("destination_unpack_latest", "collection_name/latest/full_data.csv"),
         ("destination_raw", "2020-01-01/collection_name.csv.gz"),

--- a/tests/utils/io_test.py
+++ b/tests/utils/io_test.py
@@ -135,13 +135,16 @@ def test__read_config_empty(mocker):
         io._read_config()
 
 
-def test_read_s3_config(fixture_dir):
+@pytest.mark.parametrize(
+    "config_file,number_of_destinations", [("sample_config.ini", 3), ("single_destination.ini", 1)]
+)
+def test_read_s3_config(fixture_dir, config_file, number_of_destinations):
     """Should parse s3 sections of the config."""
-    s3_sections = {k: v for k, v in io.read_s3_config(fixture_dir / "sample_config.ini")}
+    s3_sections = {k: v for k, v in io.read_s3_config(fixture_dir / config_file)}
 
-    assert len(s3_sections.items()) == 4
-    assert "source_test" in s3_sections.keys()
-    assert sum([k.startswith("destination_") for k in s3_sections.keys()], 0) == 3
+    assert len(s3_sections.items()) == number_of_destinations + 1
+    assert "source" in s3_sections.keys()
+    assert sum([k.startswith("destination") for k in s3_sections.keys()], 0) == number_of_destinations
 
     cred_keys = set(("aws_access_key_id", "aws_secret_access_key"))
     assert all([cred_keys.issubset(v.keys()) for v in s3_sections.values()])

--- a/tests/utils/s3_test.py
+++ b/tests/utils/s3_test.py
@@ -13,6 +13,7 @@ from solgate.utils import s3
     "name,default_endpoints_key,endpoint_url",
     [
         ("source_x", "source", None),
+        ("source", "source", None),
         ("anything_else", "destination", None),
         ("source_y", None, "https://s3.example.com"),
     ],
@@ -45,7 +46,7 @@ def test_s3_file_system_from_config_file_multiple_sources(fixture_dir):
 def test_s3_file_system_from_config_file_order(mocked_s3):
     """Should order clients."""
     assert [str(i) for i in mocked_s3] == [
-        "source_test",
+        "source",
         "destination_unpack_historic",
         "destination_unpack_latest",
         "destination_raw",


### PR DESCRIPTION
## Related Issues and Dependencies

…

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Allow for `config.ini` to contain section named like `source` and `destination`. Previously an additional name in there was required `source_SOMETHING` and `destination_SOMETHING`. It was really just a pain... This allows for cleaner configs when a single source and a single destination is present...
