### PR TITLE
set description content type in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     version=_version,
     description="A CLI tool for S3 data synchronizations.",
     long_description=Path("README.md").read_text(),
+    long_description_content_type="text/markdown",
     author="Tom Coufal",
     author_email="tcoufal@redhat.com",
     maintainer="Tom Coufal",


### PR DESCRIPTION
## Related Issues and Dependencies

sesheta was unable to help in pypi release due to:
`HTTPError: 400 Client Error: The description failed to render in the default format of reStructuredText. See https://pypi.org/help/#description-content-type for more information. for url: https://upload.pypi.org/legacy/`

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

https://pypi.org/help/#description-content-type

## Description

set description content type in setup.py
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

