### PR TITLE
Fix transfer logic - look for 'relpath' key instead of 'key'

### DIFF
--- a/solgate/cli.py
+++ b/solgate/cli.py
@@ -47,7 +47,7 @@ def _send(ctx, key: str = None, listing_file: str = None):
     if listing_file:
         files_to_transfer = deserialize(listing_file)
     elif key:
-        files_to_transfer = [dict(key=key)]
+        files_to_transfer = [dict(relpath=key)]
     else:
         logger.error("Nothing to send through solgate.")
         exit(1)

--- a/solgate/transfer.py
+++ b/solgate/transfer.py
@@ -141,7 +141,7 @@ def send(files_to_transfer: List[Dict[str, Any]], config_file: str = None) -> bo
     failed = []
     for source_file in files_to_transfer:
         try:
-            if not _transfer_single_file(source_file["key"], clients):
+            if not _transfer_single_file(source_file["relpath"], clients):
                 failed.append(source_file)
         except KeyError:
             logger.error("Unable to parse file key", dict(file=source_file), exc_info=True)

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -51,15 +51,15 @@ def test_list_negative(run, mocker):
 @pytest.mark.parametrize(
     "cli_args,func_args",
     [
-        (["send", "key"], [[dict(key="key")], None]),
-        (["send", "-l", "."], [[dict(key="file/key")], None]),
-        (["-c", ".", "send", "key"], [[dict(key="key")], "."]),
+        (["send", "key"], [[dict(relpath="key")], None]),
+        (["send", "-l", "."], [[dict(relpath="file/key")], None]),
+        (["-c", ".", "send", "key"], [[dict(relpath="key")], "."]),
     ],
 )
 def test_send(run, mocker, cli_args, func_args):
     """Should call proper functions on sync command."""
     mocked_send = mocker.patch("solgate.cli.send")
-    mocker.patch("solgate.cli.deserialize", return_value=[dict(key="file/key")])
+    mocker.patch("solgate.cli.deserialize", return_value=[dict(relpath="file/key")])
 
     result = run(cli_args)
 

--- a/tests/transfer_test.py
+++ b/tests/transfer_test.py
@@ -7,7 +7,7 @@ from solgate.utils import S3File
 
 
 @pytest.mark.parametrize(
-    "file_list", ([dict(key="a/b/file.csv")], [dict(key="a/b/file1.csv"), dict(key="a/b/file2.csv")])
+    "file_list", ([dict(relpath="a/b/file.csv")], [dict(relpath="a/b/file1.csv"), dict(relpath="a/b/file2.csv")])
 )
 def test_send(mocker, file_list, mocked_solgate_s3_file_system):
     """Should request files to be sent to clients."""
@@ -16,7 +16,7 @@ def test_send(mocker, file_list, mocked_solgate_s3_file_system):
     transfer.send(file_list)
 
     for f in file_list:
-        mocked_transfer_single_file.assert_any_call(f["key"], [mocked_solgate_s3_file_system])
+        mocked_transfer_single_file.assert_any_call(f["relpath"], [mocked_solgate_s3_file_system])
 
 
 @pytest.mark.parametrize("file_list", ([], [dict()], [dict(not_a_key="a/b/file.csv")], [dict(key="file.csv"), dict()]))


### PR DESCRIPTION
## Related Issues and Dependencies

…

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

During testing of #39 I've discovered a bug in the transfer logic - the code was looking up the Object's `key` in the listing file, instead of `relpath`. This resulted in the `base_path` not being subtracted from the file key, therefore the transfer was not able to locate the source file properly.

When listing file is used for transfer, the `relpath` attribute of each file is present there. When using direct key in cli, user is expected to use the `relpath` instead of full key.

```sh
$ cat config.ini
[source]
base_path = BUCKET/a/b
...
# Bad
solgate send BUCKET/a/b/file.txt
# Good, expected
solgate send file.txt
```
