### PR TITLE
Allow reports without config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,15 +84,55 @@ solgate list
 solgate transfer
 ```
 
-### Nofitication service
+### Notification service
+
+Send an workflow status alert via email from Argo environment.
+
+Command expects to be passed values matching available Argo variable format as described [here](https://github.com/argoproj/argo/blob/master/docs/variables.md#global).
 
 ```sh
-solgate notify
+solgate report
 ```
+
+Options can be set either via CLI argument or via environment variable:
+
+<!-- Img tag enforces additional width on the column, so GitHub doesn't break line on the --option after dashes.  -->
+<!-- markdownlint-capture -->
+<!-- markdownlint-disable  no-inline-html -->
+
+- Options which map to Argo Workflow variables:
+
+  | CLI option <img width=150/> | Environment variable name | Value should map to Argo workflow variable | Description                                                         |
+  | --------------------------- | ------------------------- | ------------------------------------------ | ------------------------------------------------------------------- |
+  | `--failures`                | `WORKFLOW_FAILURES`       | `{{workflow.failures}}`                    | JSON serialized into a string listing all the failed workflow nodes |
+  | `-n`, `--name`              | `WORKFLOW_NAME`           | `{{workflow.name}}`                        | Workflow instance name.                                             |
+  | `--namespace`               | `WORKFLOW_NAMESPACE`      | `{{workflow.namespace}}`                   | Project namespace where the workflow was executed.                  |
+  | `-s`, `--status`            | `WORKFLOW_STATUS`         | `{{workflow.status}}`                      | Current status of the workflow execution.                           |
+  | `-t`, `--timestamp`         | `WORKFLOW_TIMESTAMP`      | `{{workflow.creationTimestamp}}`           | Workflow execution timestamp.                                       |
+
+- Options which map to config file entries. Priority order:
+
+  ```sh
+  CLI option > Environment variable > Config file entry > Default value
+  ```
+
+  | CLI option <img width=20/> | Environment variable name | Config file entry in `[solgate]` section | Description                                                            |
+  | -------------------------- | ------------------------- | ---------------------------------------- | ---------------------------------------------------------------------- |
+  | `--from`                   | `ALERT_SENDER`            | `alerts_from`                            | Email alert sender address. Defaults to solgate-alerts@redhat.com.     |
+  | `--to`                     | `ALERT_RECIPIENT`         | `alerts_to`                              | Email alert recipient address. Defaults to data-hub-alerts@redhat.com. |
+  | `--smtp`                   | `SMTP_SERVER`             | `alerts_smtp_server`                     | SMTP server URL. Defaults to smtp.corp.redhat.com.                     |
+
+- Other:
+
+  | CLI option | Environment variable name | Description                       |
+  | ---------- | ------------------------- | --------------------------------- |
+  | `--host`   | `ARGO_UI_HOST`            | Argo UI external facing hostname. |
+
+<!-- markdownlint-restore -->
 
 ## Workflow manifests
 
-Additionally to the `solgate` package source code this repository also features deployment manifests in the `manifests` folder. The current implementation of Kubernetes manifests relies on [Argo](https://argoproj.github.io/argo/), [Argo Events](https://argoproj.github.io/argo-events/) and are structured in a [Kustomize](https://kustomize.io/) format. Environments for deployment are specified in the `manifests/overlays/ENV_NAME` folder.
+Additionally to the `solgate` package this repository also features deployment manifests in the `manifests` folder. The current implementation of Kubernetes manifests relies on [Argo](https://argoproj.github.io/argo/), [Argo Events](https://argoproj.github.io/argo-events/) and are structured in a [Kustomize](https://kustomize.io/) format. Environments for deployment are specified in the `manifests/overlays/ENV_NAME` folder.
 
 Each environment features multiple solgate workflow instances. Configuration `config.ini` file and selected triggers are defined in instance subfolder within the particular environment folder.
 

--- a/solgate/cli.py
+++ b/solgate/cli.py
@@ -104,10 +104,7 @@ def _list(ctx, output: str = None):
 )
 @click.option("-t", "--timestamp", envvar="WORKFLOW_TIMESTAMP", type=click.STRING, help="Workflow execution timestamp.")
 @click.option(
-    "--host",
-    envvar="ARGO_UI_HOST",
-    type=click.STRING,
-    help="Argo UI external facing route host, which can be used to format hyperlinks to given workflow execution.",
+    "--host", envvar="ARGO_UI_HOST", type=click.STRING, help="Argo UI external facing hostname.",
 )
 @click.option(
     "--from",

--- a/tests/transfer_test.py
+++ b/tests/transfer_test.py
@@ -39,8 +39,8 @@ def test_send_unable_to_transfer(mocker, mocked_solgate_s3_file_system):
     mocker.patch("solgate.transfer._transfer_single_file", return_value=False)
 
     spy_send = mocker.spy(transfer.logger, "error")
-    assert transfer.send([dict(key="a/b/file.csv")]) is False
-    spy_send.assert_called_with(mocker.ANY, dict(failed_files=[dict(key="a/b/file.csv")]))
+    assert transfer.send([dict(relpath="a/b/file.csv")]) is False
+    spy_send.assert_called_with(mocker.ANY, dict(failed_files=[dict(relpath="a/b/file.csv")]))
 
 
 @pytest.mark.parametrize("mocked_s3", ["sample_config.ini"], indirect=["mocked_s3"])


### PR DESCRIPTION
## Related Issues and Dependencies

…

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Simplify the `solgate report` command by allowing to specify the sender, recipient and SMTP server via CLI and env var. That allows use of the reporter without a config file all together, making solgate reporter usable in non-solgate scenarios that wants to use Argo email reporting.