### PR TITLE
fix: Optional param in wftmpl

### DIFF
--- a/manifests/base/wftmpl.yaml
+++ b/manifests/base/wftmpl.yaml
@@ -29,8 +29,7 @@ spec:
         command: ["solgate", "list"]
         args:
           - "-o"
-          - "/mnt/vol/filelist.json"
-          - "{{workflow.parameters.additional-lookup-params}}"
+          - "/mnt/vol/filelist.json {{workflow.parameters.additional-lookup-params}}"
         resources:
           limits:
             cpu: 500m


### PR DESCRIPTION
SSIA

separate optional param makes the pipeline fail if left empty