### PR TITLE
Switch to boto3, add `--silent`, `--dry-run` and retry loginc

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -18,6 +18,7 @@ logstash-formatter = ">=0.5.17"
 jinja2 = ">=2.11"
 click = "*"
 pyyaml = "*"
+boto3 = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile
+++ b/Pipfile
@@ -19,6 +19,7 @@ jinja2 = ">=2.11"
 click = "*"
 pyyaml = "*"
 boto3 = "*"
+backoff = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "876a58bb9f27cb190b2c0707b6cb5db746481559dfccb9efc9ecb85a93b972a2"
+            "sha256": "9e95cea8a3512120063a8400c76fc2715a50058d0618add22743538bd5c02260"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,14 @@
         ]
     },
     "default": {
+        "backoff": {
+            "hashes": [
+                "sha256:5e73e2cbe780e1915a204799dba0a01896f45f4385e636bcca7a0614d879d0cd",
+                "sha256:b8fba021fac74055ac05eb7c7bfce4723aedde6cd0a504e5326bcb0bdd6d19a4"
+            ],
+            "index": "pypi",
+            "version": "==1.10.0"
+        },
         "boto3": {
             "hashes": [
                 "sha256:7059b3dbb6b474c6ef836aa3bb53eb7b3e474133f3e4cb2a3a3adcc55e2b2b9d",

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f827298a89f166071c6ee1ea82e22d52c2512f0d6232daba1749f65a3a64fd83"
+            "sha256": "876a58bb9f27cb190b2c0707b6cb5db746481559dfccb9efc9ecb85a93b972a2"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,13 +16,21 @@
         ]
     },
     "default": {
+        "boto3": {
+            "hashes": [
+                "sha256:7059b3dbb6b474c6ef836aa3bb53eb7b3e474133f3e4cb2a3a3adcc55e2b2b9d",
+                "sha256:bc8b6e98375f71dde0f51e08d415a72e3d8389042ea07d216ac82c98060e7149"
+            ],
+            "index": "pypi",
+            "version": "==1.17.75"
+        },
         "botocore": {
             "hashes": [
-                "sha256:414e1721d381095767db1cf673257fdfec639da3be9405a41d49cc859b817d68",
-                "sha256:b7afebca1fd6ca1f8af79f377a445d474e3bd2cf88e704169d6713a6362a304f"
+                "sha256:80fc9a463bcc6368ed95d4b10717f5bb87288b930b3ccf96ce480d1c65e20e5c",
+                "sha256:ab1bd5d5f86a4fdd194129a6102e5193209d3c4676dd76881769d6894bbaab7e"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.20.71"
+            "version": "==1.20.75"
         },
         "click": {
             "hashes": [
@@ -34,19 +42,19 @@
         },
         "fsspec": {
             "hashes": [
-                "sha256:70dae1d8d51072c4a1196acb9ba1bf8f5b9cdd83c4bb67e8a31dac604a49594b",
-                "sha256:8b1a69884855d1a8c038574292e8b861894c3373282d9a469697a2b41d5289a6"
+                "sha256:30064d89b00c6acfe5d8e027b6c0ef3df25ca17fd1d5cad2e8208c9aa5300f8d",
+                "sha256:a08daa28ecb98544350d62f8307a7678e410c4b5245e04d14fcf4a3f13e959a7"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2021.4.0"
+            "version": "==2021.5.0"
         },
         "jinja2": {
             "hashes": [
-                "sha256:2f2de5285cf37f33d33ecd4a9080b75c87cd0c1994d5a9c6df17131ea1f049c6",
-                "sha256:ea8d7dd814ce9df6de6a761ec7f1cac98afe305b8cdc4aaae4e114b8d8ce24c5"
+                "sha256:1f06f2da51e7b56b8f238affdd6b4e2c61e39598a378cc49345bc1bd42a978a4",
+                "sha256:703f484b47a6af502e743c9122595cc812b0271f661722403114f71a79d0f5a4"
             ],
             "index": "pypi",
-            "version": "==3.0.0"
+            "version": "==3.0.1"
         },
         "jmespath": {
             "hashes": [
@@ -65,43 +73,43 @@
         },
         "markupsafe": {
             "hashes": [
-                "sha256:007dc055dbce5b1104876acee177dbfd18757e19d562cd440182e1f492e96b95",
-                "sha256:031bf79a27d1c42f69c276d6221172417b47cb4b31cdc73d362a9bf5a1889b9f",
-                "sha256:161d575fa49395860b75da5135162481768b11208490d5a2143ae6785123e77d",
-                "sha256:24bbc3507fb6dfff663af7900a631f2aca90d5a445f272db5fc84999fa5718bc",
-                "sha256:2efaeb1baff547063bad2b2893a8f5e9c459c4624e1a96644bbba08910ae34e0",
-                "sha256:32200f562daaab472921a11cbb63780f1654552ae49518196fc361ed8e12e901",
-                "sha256:3261fae28155e5c8634dd7710635fe540a05b58f160cef7713c7700cb9980e66",
-                "sha256:3b54a9c68995ef4164567e2cd1a5e16db5dac30b2a50c39c82db8d4afaf14f63",
-                "sha256:3c352ff634e289061711608f5e474ec38dbaa21e3e168820d53d5f4015e5b91b",
-                "sha256:3fb47f97f1d338b943126e90b79cad50d4fcfa0b80637b5a9f468941dbbd9ce5",
-                "sha256:441ce2a8c17683d97e06447fcbccbdb057cbf587c78eb75ae43ea7858042fe2c",
-                "sha256:45535241baa0fc0ba2a43961a1ac7562ca3257f46c4c3e9c0de38b722be41bd1",
-                "sha256:4aca81a687975b35e3e80bcf9aa93fe10cd57fac37bf18b2314c186095f57e05",
-                "sha256:4cc563836f13c57f1473bc02d1e01fc37bab70ad4ee6be297d58c1d66bc819bf",
-                "sha256:4fae0677f712ee090721d8b17f412f1cbceefbf0dc180fe91bab3232f38b4527",
-                "sha256:58bc9fce3e1557d463ef5cee05391a05745fd95ed660f23c1742c711712c0abb",
-                "sha256:664832fb88b8162268928df233f4b12a144a0c78b01d38b81bdcf0fc96668ecb",
-                "sha256:70820a1c96311e02449591cbdf5cd1c6a34d5194d5b55094ab725364375c9eb2",
-                "sha256:79b2ae94fa991be023832e6bcc00f41dbc8e5fe9d997a02db965831402551730",
-                "sha256:83cf0228b2f694dcdba1374d5312f2277269d798e65f40344964f642935feac1",
-                "sha256:87de598edfa2230ff274c4de7fcf24c73ffd96208c8e1912d5d0fee459767d75",
-                "sha256:8f806bfd0f218477d7c46a11d3e52dc7f5fdfaa981b18202b7dc84bbc287463b",
-                "sha256:90053234a6479738fd40d155268af631c7fca33365f964f2208867da1349294b",
-                "sha256:a00dce2d96587651ef4fa192c17e039e8cfab63087c67e7d263a5533c7dad715",
-                "sha256:a08cd07d3c3c17cd33d9e66ea9dee8f8fc1c48e2d11bd88fd2dc515a602c709b",
-                "sha256:a19d39b02a24d3082856a5b06490b714a9d4179321225bbf22809ff1e1887cc8",
-                "sha256:d00a669e4a5bec3ee6dbeeeedd82a405ced19f8aeefb109a012ea88a45afff96",
-                "sha256:dab0c685f21f4a6c95bfc2afd1e7eae0033b403dd3d8c1b6d13a652ada75b348",
-                "sha256:df561f65049ed3556e5b52541669310e88713fdae2934845ec3606f283337958",
-                "sha256:e4570d16f88c7f3032ed909dc9e905a17da14a1c4cfd92608e3fda4cb1208bbd",
-                "sha256:e77e4b983e2441aff0c0d07ee711110c106b625f440292dfe02a2f60c8218bd6",
-                "sha256:e79212d09fc0e224d20b43ad44bb0a0a3416d1e04cf6b45fed265114a5d43d20",
-                "sha256:f58b5ba13a5689ca8317b98439fccfbcc673acaaf8241c1869ceea40f5d585bf",
-                "sha256:fef86115fdad7ae774720d7103aa776144cf9b66673b4afa9bcaa7af990ed07b"
+                "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298",
+                "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64",
+                "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b",
+                "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567",
+                "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff",
+                "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74",
+                "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35",
+                "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26",
+                "sha256:3c112550557578c26af18a1ccc9e090bfe03832ae994343cfdacd287db6a6ae7",
+                "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75",
+                "sha256:49e3ceeabbfb9d66c3aef5af3a60cc43b85c33df25ce03d0031a608b0a8b2e3f",
+                "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135",
+                "sha256:53edb4da6925ad13c07b6d26c2a852bd81e364f95301c66e930ab2aef5b5ddd8",
+                "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a",
+                "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914",
+                "sha256:6557b31b5e2c9ddf0de32a691f2312a32f77cd7681d8af66c2692efdbef84c18",
+                "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8",
+                "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2",
+                "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d",
+                "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b",
+                "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f",
+                "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb",
+                "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833",
+                "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415",
+                "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902",
+                "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9",
+                "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d",
+                "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066",
+                "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f",
+                "sha256:f5653a225f31e113b152e56f154ccbe59eeb1c7487b39b9d9f9cdb58e6c79dc5",
+                "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94",
+                "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509",
+                "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51",
+                "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2.0.0"
+            "version": "==2.0.1"
         },
         "python-dateutil": {
             "hashes": [
@@ -152,6 +160,13 @@
                 "sha256:91c1dfb45e5217bd441a7a560946fe865ced6225ff7eb0fb459fe6e601a95ed3"
             ],
             "index": "pypi",
+            "version": "==0.4.2"
+        },
+        "s3transfer": {
+            "hashes": [
+                "sha256:9b3752887a2880690ce628bc263d6d13a3864083aeacff4890c1c9839a5eb0bc",
+                "sha256:cb022f4b16551edebbb31a377d3f09600dbada7363d8c5db7976e7f47732e1b2"
+            ],
             "version": "==0.4.2"
         },
         "six": {
@@ -205,19 +220,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:bcb1b76ca5a60586181ad202b19f4c50cb7c22ac68cae20f997abe311e22bf2a",
-                "sha256:edf9b3b36e08cd575a9458bf59871852335aceb5db2d07bfc8530bae3a97d045"
+                "sha256:7059b3dbb6b474c6ef836aa3bb53eb7b3e474133f3e4cb2a3a3adcc55e2b2b9d",
+                "sha256:bc8b6e98375f71dde0f51e08d415a72e3d8389042ea07d216ac82c98060e7149"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.17.71"
+            "index": "pypi",
+            "version": "==1.17.75"
         },
         "botocore": {
             "hashes": [
-                "sha256:414e1721d381095767db1cf673257fdfec639da3be9405a41d49cc859b817d68",
-                "sha256:b7afebca1fd6ca1f8af79f377a445d474e3bd2cf88e704169d6713a6362a304f"
+                "sha256:80fc9a463bcc6368ed95d4b10717f5bb87288b930b3ccf96ce480d1c65e20e5c",
+                "sha256:ab1bd5d5f86a4fdd194129a6102e5193209d3c4676dd76881769d6894bbaab7e"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.20.71"
+            "version": "==1.20.75"
         },
         "certifi": {
             "hashes": [
@@ -229,14 +244,23 @@
         "cffi": {
             "hashes": [
                 "sha256:005a36f41773e148deac64b08f233873a4d0c18b053d37da83f6af4d9087b813",
+                "sha256:04c468b622ed31d408fea2346bec5bbffba2cc44226302a0de1ade9f5ea3d373",
+                "sha256:06d7cd1abac2ffd92e65c0609661866709b4b2d82dd15f611e602b9b188b0b69",
+                "sha256:06db6321b7a68b2bd6df96d08a5adadc1fa0e8f419226e25b2a5fbf6ccc7350f",
                 "sha256:0857f0ae312d855239a55c81ef453ee8fd24136eaba8e87a2eceba644c0d4c06",
+                "sha256:0f861a89e0043afec2a51fd177a567005847973be86f709bbb044d7f42fc4e05",
                 "sha256:1071534bbbf8cbb31b498d5d9db0f274f2f7a865adca4ae429e147ba40f73dea",
                 "sha256:158d0d15119b4b7ff6b926536763dc0714313aa59e320ddf787502c70c4d4bee",
+                "sha256:1bf1ac1984eaa7675ca8d5745a8cb87ef7abecb5592178406e55858d411eadc0",
                 "sha256:1f436816fc868b098b0d63b8920de7d208c90a67212546d02f84fe78a9c26396",
+                "sha256:24a570cd11895b60829e941f2613a4f79df1a27344cbbb82164ef2e0116f09c7",
+                "sha256:24ec4ff2c5c0c8f9c6b87d5bb53555bf267e1e6f70e52e5a9740d32861d36b6f",
                 "sha256:2894f2df484ff56d717bead0a5c2abb6b9d2bf26d6960c4604d5c48bbc30ee73",
                 "sha256:29314480e958fd8aab22e4a58b355b629c59bf5f2ac2492b61e3dc06d8c7a315",
+                "sha256:293e7ea41280cb28c6fcaaa0b1aa1f533b8ce060b9e701d78511e1e6c4a1de76",
                 "sha256:34eff4b97f3d982fb93e2831e6750127d1355a923ebaeeb565407b3d2f8d41a1",
                 "sha256:35f27e6eb43380fa080dccf676dece30bef72e4a67617ffda586641cd4508d49",
+                "sha256:3c3f39fa737542161d8b0d680df2ec249334cd70a8f420f71c9304bd83c3cbed",
                 "sha256:3d3dd4c9e559eb172ecf00a2a7517e97d1e96de2a5e610bd9b68cea3925b4892",
                 "sha256:43e0b9d9e2c9e5d152946b9c5fe062c151614b262fda2e7b201204de0b99e482",
                 "sha256:48e1c69bbacfc3d932221851b39d49e81567a4d4aac3b21258d9c24578280058",
@@ -244,6 +268,7 @@
                 "sha256:58e3f59d583d413809d60779492342801d6e82fefb89c86a38e040c16883be53",
                 "sha256:5de7970188bb46b7bf9858eb6890aad302577a5f6f75091fd7cdd3ef13ef3045",
                 "sha256:65fa59693c62cf06e45ddbb822165394a288edce9e276647f0046e1ec26920f3",
+                "sha256:681d07b0d1e3c462dd15585ef5e33cb021321588bebd910124ef4f4fb71aef55",
                 "sha256:69e395c24fc60aad6bb4fa7e583698ea6cc684648e1ffb7fe85e3c1ca131a7d5",
                 "sha256:6c97d7350133666fbb5cf4abdc1178c812cb205dc6f41d174a7b0f18fb93337e",
                 "sha256:6e4714cc64f474e4d6e37cfff31a814b509a35cb17de4fb1999907575684479c",
@@ -261,8 +286,10 @@
                 "sha256:b85eb46a81787c50650f2392b9b4ef23e1f126313b9e0e9013b35c15e4288e2e",
                 "sha256:bb89f306e5da99f4d922728ddcd6f7fcebb3241fc40edebcb7284d7514741991",
                 "sha256:cbde590d4faaa07c72bf979734738f328d239913ba3e043b1e98fe9a39f8b2b6",
+                "sha256:cc5a8e069b9ebfa22e26d0e6b97d6f9781302fe7f4f2b8776c3e1daea35f1adc",
                 "sha256:cd2868886d547469123fadc46eac7ea5253ea7fcb139f12e1dfc2bbd406427d1",
                 "sha256:d42b11d692e11b6634f7613ad8df5d6d5f8875f5d48939520d351007b3c13406",
+                "sha256:df5052c5d867c1ea0b311fb7c3cd28b19df469c056f7fdcfe88c7473aa63e333",
                 "sha256:f2d45f97ab6bb54753eab54fffe75aaf3de4ff2341c9daee1987ee1837636f1d",
                 "sha256:fd78e5fee591709f32ef6edb9a015b4aa1a5022598e36227500c8f4e02328d9c"
             ],
@@ -293,6 +320,9 @@
             "version": "==0.4.4"
         },
         "coverage": {
+            "extras": [
+                "toml"
+            ],
             "hashes": [
                 "sha256:004d1880bed2d97151facef49f08e255a20ceb6f9432df75f4eef018fdd5a78c",
                 "sha256:01d84219b5cdbfc8122223b39a954820929497a1cb1422824bb86b07b74594b6",
@@ -409,11 +439,11 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:2f2de5285cf37f33d33ecd4a9080b75c87cd0c1994d5a9c6df17131ea1f049c6",
-                "sha256:ea8d7dd814ce9df6de6a761ec7f1cac98afe305b8cdc4aaae4e114b8d8ce24c5"
+                "sha256:1f06f2da51e7b56b8f238affdd6b4e2c61e39598a378cc49345bc1bd42a978a4",
+                "sha256:703f484b47a6af502e743c9122595cc812b0271f661722403114f71a79d0f5a4"
             ],
             "index": "pypi",
-            "version": "==3.0.0"
+            "version": "==3.0.1"
         },
         "jmespath": {
             "hashes": [
@@ -433,43 +463,43 @@
         },
         "markupsafe": {
             "hashes": [
-                "sha256:007dc055dbce5b1104876acee177dbfd18757e19d562cd440182e1f492e96b95",
-                "sha256:031bf79a27d1c42f69c276d6221172417b47cb4b31cdc73d362a9bf5a1889b9f",
-                "sha256:161d575fa49395860b75da5135162481768b11208490d5a2143ae6785123e77d",
-                "sha256:24bbc3507fb6dfff663af7900a631f2aca90d5a445f272db5fc84999fa5718bc",
-                "sha256:2efaeb1baff547063bad2b2893a8f5e9c459c4624e1a96644bbba08910ae34e0",
-                "sha256:32200f562daaab472921a11cbb63780f1654552ae49518196fc361ed8e12e901",
-                "sha256:3261fae28155e5c8634dd7710635fe540a05b58f160cef7713c7700cb9980e66",
-                "sha256:3b54a9c68995ef4164567e2cd1a5e16db5dac30b2a50c39c82db8d4afaf14f63",
-                "sha256:3c352ff634e289061711608f5e474ec38dbaa21e3e168820d53d5f4015e5b91b",
-                "sha256:3fb47f97f1d338b943126e90b79cad50d4fcfa0b80637b5a9f468941dbbd9ce5",
-                "sha256:441ce2a8c17683d97e06447fcbccbdb057cbf587c78eb75ae43ea7858042fe2c",
-                "sha256:45535241baa0fc0ba2a43961a1ac7562ca3257f46c4c3e9c0de38b722be41bd1",
-                "sha256:4aca81a687975b35e3e80bcf9aa93fe10cd57fac37bf18b2314c186095f57e05",
-                "sha256:4cc563836f13c57f1473bc02d1e01fc37bab70ad4ee6be297d58c1d66bc819bf",
-                "sha256:4fae0677f712ee090721d8b17f412f1cbceefbf0dc180fe91bab3232f38b4527",
-                "sha256:58bc9fce3e1557d463ef5cee05391a05745fd95ed660f23c1742c711712c0abb",
-                "sha256:664832fb88b8162268928df233f4b12a144a0c78b01d38b81bdcf0fc96668ecb",
-                "sha256:70820a1c96311e02449591cbdf5cd1c6a34d5194d5b55094ab725364375c9eb2",
-                "sha256:79b2ae94fa991be023832e6bcc00f41dbc8e5fe9d997a02db965831402551730",
-                "sha256:83cf0228b2f694dcdba1374d5312f2277269d798e65f40344964f642935feac1",
-                "sha256:87de598edfa2230ff274c4de7fcf24c73ffd96208c8e1912d5d0fee459767d75",
-                "sha256:8f806bfd0f218477d7c46a11d3e52dc7f5fdfaa981b18202b7dc84bbc287463b",
-                "sha256:90053234a6479738fd40d155268af631c7fca33365f964f2208867da1349294b",
-                "sha256:a00dce2d96587651ef4fa192c17e039e8cfab63087c67e7d263a5533c7dad715",
-                "sha256:a08cd07d3c3c17cd33d9e66ea9dee8f8fc1c48e2d11bd88fd2dc515a602c709b",
-                "sha256:a19d39b02a24d3082856a5b06490b714a9d4179321225bbf22809ff1e1887cc8",
-                "sha256:d00a669e4a5bec3ee6dbeeeedd82a405ced19f8aeefb109a012ea88a45afff96",
-                "sha256:dab0c685f21f4a6c95bfc2afd1e7eae0033b403dd3d8c1b6d13a652ada75b348",
-                "sha256:df561f65049ed3556e5b52541669310e88713fdae2934845ec3606f283337958",
-                "sha256:e4570d16f88c7f3032ed909dc9e905a17da14a1c4cfd92608e3fda4cb1208bbd",
-                "sha256:e77e4b983e2441aff0c0d07ee711110c106b625f440292dfe02a2f60c8218bd6",
-                "sha256:e79212d09fc0e224d20b43ad44bb0a0a3416d1e04cf6b45fed265114a5d43d20",
-                "sha256:f58b5ba13a5689ca8317b98439fccfbcc673acaaf8241c1869ceea40f5d585bf",
-                "sha256:fef86115fdad7ae774720d7103aa776144cf9b66673b4afa9bcaa7af990ed07b"
+                "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298",
+                "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64",
+                "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b",
+                "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567",
+                "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff",
+                "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74",
+                "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35",
+                "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26",
+                "sha256:3c112550557578c26af18a1ccc9e090bfe03832ae994343cfdacd287db6a6ae7",
+                "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75",
+                "sha256:49e3ceeabbfb9d66c3aef5af3a60cc43b85c33df25ce03d0031a608b0a8b2e3f",
+                "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135",
+                "sha256:53edb4da6925ad13c07b6d26c2a852bd81e364f95301c66e930ab2aef5b5ddd8",
+                "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a",
+                "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914",
+                "sha256:6557b31b5e2c9ddf0de32a691f2312a32f77cd7681d8af66c2692efdbef84c18",
+                "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8",
+                "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2",
+                "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d",
+                "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b",
+                "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f",
+                "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb",
+                "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833",
+                "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415",
+                "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902",
+                "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9",
+                "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d",
+                "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066",
+                "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f",
+                "sha256:f5653a225f31e113b152e56f154ccbe59eeb1c7487b39b9d9f9cdb58e6c79dc5",
+                "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94",
+                "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509",
+                "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51",
+                "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2.0.0"
+            "version": "==2.0.1"
         },
         "more-itertools": {
             "hashes": [
@@ -594,11 +624,11 @@
         },
         "pytest-cov": {
             "hashes": [
-                "sha256:359952d9d39b9f822d9d29324483e7ba04a3a17dd7d05aa6beb7ea01e359e5f7",
-                "sha256:bdb9fdb0b85a7cc825269a4c56b48ccaa5c7e365054b6038772c32ddcdc969da"
+                "sha256:8535764137fecce504a49c2b742288e3d34bc09eed298ad65963616cc98fd45e",
+                "sha256:95d4933dcbbacfa377bb60b29801daa30d90c33981ab2a79e9ab4452c165066e"
             ],
             "index": "pypi",
-            "version": "==2.11.1"
+            "version": "==2.12.0"
         },
         "pytest-mock": {
             "hashes": [

--- a/solgate/cli.py
+++ b/solgate/cli.py
@@ -43,8 +43,16 @@ def cli(ctx, config_filename, config_folder):  # noqa: D301
         "If set, solgate will ignore the KEY argument and use the listing file instead."
     ),
 )
+@click.option(
+    "--dry-run",
+    "-n",
+    type=click.BOOL,
+    is_flag=True,
+    default=False,
+    help="Do not execute file transfers, just list what would happen.",
+)
 @click.pass_context
-def _send(ctx, key: str = None, listing_file: str = None):
+def _send(ctx, key: str = None, listing_file: str = None, dry_run: bool = False):
     """Sync S3 objects.
 
     KEY points to a S3 Object within the source base path, that is meant to be transferred.
@@ -57,7 +65,7 @@ def _send(ctx, key: str = None, listing_file: str = None):
         files_to_transfer = []
 
     try:
-        send(files_to_transfer, ctx.obj["config"])
+        send(files_to_transfer, ctx.obj["config"], dry_run)
     except FileNotFoundError as e:
         logger.error(e, exc_info=True)
         raise NoFilesToSyncError(*e.args)

--- a/solgate/cli.py
+++ b/solgate/cli.py
@@ -52,7 +52,7 @@ def _send(ctx, key: str = None, listing_file: str = None):
     if listing_file:
         files_to_transfer = deserialize(listing_file)
     elif key:
-        files_to_transfer = [dict(relpath=key)]
+        files_to_transfer = [dict(key=key)]
     else:
         files_to_transfer = []
 
@@ -180,7 +180,7 @@ def _report(
     try:
         config = read_general_config(**ctx.obj["config"])
     except IOError:
-        logger.warn("Config file is not present or not valid, alerting to/from default email address.")
+        logger.warning("Config file is not present or not valid, alerting to/from default email address.")
         config = {}
 
     params = dict(alerts_from=from_, alerts_to=to, alerts_smtp_server=smtp)

--- a/solgate/cli.py
+++ b/solgate/cli.py
@@ -79,8 +79,15 @@ def _send(ctx, key: str = None, listing_file: str = None):
 @click.option(
     "--backfill", type=click.BOOL, default=False, help="Ignore TIMEDELTA constrain and run a backfill lookup."
 )
+@click.option(
+    "--silent",
+    type=click.BOOL,
+    is_flag=True,
+    default=False,
+    help="Ignore TIMEDELTA constrain and run a backfill lookup.",
+)
 @click.pass_context
-def _list(ctx, backfill: bool, output: str = None):
+def _list(ctx, backfill: bool, silent: bool = False, output: str = None):
     """Query the source bucket for files ready to be transferred.
 
     Only files newer than `timedelta` config value (added or modified) are listed.
@@ -89,7 +96,7 @@ def _list(ctx, backfill: bool, output: str = None):
         for file in list_source(ctx.obj["config"], backfill):
             if output:
                 serialize(file, output)
-            else:
+            if not silent:
                 click.echo(file)
     except ValueError as e:
         logger.error(e, exc_info=True)

--- a/solgate/transfer.py
+++ b/solgate/transfer.py
@@ -146,7 +146,7 @@ def send(files_to_transfer: List[Dict[str, Any]], config: Dict[str, Any]) -> boo
     failed = []
     for source_file in files_to_transfer:
         try:
-            if not _transfer_single_file(source_file["relpath"], clients):
+            if not _transfer_single_file(source_file["key"], clients):
                 failed.append(source_file)
         except KeyError:
             logger.error("Unable to parse file key", dict(file=source_file), exc_info=True)

--- a/solgate/utils/s3.py
+++ b/solgate/utils/s3.py
@@ -192,6 +192,10 @@ class S3FileSystem:
         """Use name as a string destriptor for instances."""
         return self.name
 
+    def __repr__(self):
+        """Use self.name as an identifier."""
+        return f"S3FileSystem(name='{self.name}')"
+
 
 @dataclass
 class S3File:

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -69,9 +69,11 @@ def test_list_negative(run, mocker, side_effect, errno):
 @pytest.mark.parametrize(
     "cli_args,func_args",
     [
-        (["send", "key"], [[dict(key="key")], context()]),
-        (["send", "-l", "."], [[dict(key="file/key")], context()]),
-        (["-c", ".", "send", "key"], [[dict(key="key")], context(path=Path("."))]),
+        (["send", "key"], [[dict(key="key")], context(), None]),
+        (["send", "-l", "."], [[dict(key="file/key")], context(), None]),
+        (["-c", ".", "send", "key"], [[dict(key="key")], context(path=Path(".")), None]),
+        (["send", "key", "--dry-run"], [[dict(key="key")], context(), True]),
+        (["send", "key", "-n"], [[dict(key="key")], context(), True]),
     ],
 )
 def test_send(run, mocker, cli_args, func_args):

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -69,15 +69,15 @@ def test_list_negative(run, mocker, side_effect, errno):
 @pytest.mark.parametrize(
     "cli_args,func_args",
     [
-        (["send", "key"], [[dict(relpath="key")], context()]),
-        (["send", "-l", "."], [[dict(relpath="file/key")], context()]),
-        (["-c", ".", "send", "key"], [[dict(relpath="key")], context(path=Path("."))]),
+        (["send", "key"], [[dict(key="key")], context()]),
+        (["send", "-l", "."], [[dict(key="file/key")], context()]),
+        (["-c", ".", "send", "key"], [[dict(key="key")], context(path=Path("."))]),
     ],
 )
 def test_send(run, mocker, cli_args, func_args):
     """Should call proper functions on sync command."""
     mocked_send = mocker.patch("solgate.cli.send")
-    mocker.patch("solgate.cli.deserialize", return_value=[dict(relpath="file/key")])
+    mocker.patch("solgate.cli.deserialize", return_value=[dict(key="file/key")])
 
     result = run(cli_args)
 
@@ -174,7 +174,7 @@ def test_report(run, mocker, cli_args, func_args, fixture_dir, env):
         cli_args[1] = fixture_dir
     else:
         # If config wasn't specified, spy for a warning
-        logger_spy = mocker.spy(logger, "warn")
+        logger_spy = mocker.spy(logger, "warning")
 
     run(cli_args, env)
 

--- a/tests/lookup_test.py
+++ b/tests/lookup_test.py
@@ -11,19 +11,6 @@ from solgate import lookup
 @pytest.mark.parametrize(
     "input,output",
     [
-        (dict(Size=1), dict(size=1)),
-        (dict(something=False), dict()),
-        (dict(LastModified=1, KEY="file.csv", Key="file.csv"), dict(lastmodified=1, key="file.csv")),
-    ],
-)
-def test_subset_metadata(input, output):
-    """Should filter metadata."""
-    assert output == lookup.subset_metadata(input)
-
-
-@pytest.mark.parametrize(
-    "input,output",
-    [
         ("1d", timedelta(days=1)),
         ("1h", timedelta(hours=1)),
         ("1m", timedelta(minutes=1)),

--- a/tests/transfer_test.py
+++ b/tests/transfer_test.py
@@ -8,7 +8,7 @@ from solgate.utils import S3File
 
 
 @pytest.mark.parametrize(
-    "file_list", ([dict(relpath="a/b/file.csv")], [dict(relpath="a/b/file1.csv"), dict(relpath="a/b/file2.csv")])
+    "file_list", ([dict(key="a/b/file.csv")], [dict(key="a/b/file1.csv"), dict(key="a/b/file2.csv")])
 )
 def test_send(mocker, file_list, mocked_solgate_s3_file_system):
     """Should request files to be sent to clients."""
@@ -17,7 +17,7 @@ def test_send(mocker, file_list, mocked_solgate_s3_file_system):
     transfer.send(file_list, {})
 
     for f in file_list:
-        mocked_transfer_single_file.assert_any_call(f["relpath"], [mocked_solgate_s3_file_system])
+        mocked_transfer_single_file.assert_any_call(f["key"], [mocked_solgate_s3_file_system])
 
 
 @pytest.mark.parametrize(
@@ -56,11 +56,14 @@ def test_send_not_configured_properly(mocker):
 
 def test_send_unable_to_transfer(mocker, mocked_solgate_s3_file_system):
     """Should log failures."""
-    mocker.patch("solgate.transfer._transfer_single_file", return_value=False)
+    mocker.patch("solgate.transfer._transfer_single_file", side_effect=transfer.TransferFailed())
+    logger_spy = mocker.spy(transfer.logger, "error")
 
     with pytest.raises(IOError) as e:
-        transfer.send([dict(relpath="a/b/file.csv")], {})
-        assert e.args[1] == dict(failed_files=[dict(relpath="a/b/file.csv")])
+        transfer.send([dict(key="a/b/file.csv")], {})
+        assert e.args[1] == dict(failed_files=[dict(key="a/b/file.csv")])
+
+    logger_spy.assert_called_once_with("Max retries reached", mocker.ANY, exc_info=True)
 
 
 @pytest.mark.parametrize("mocked_s3", ["sample_config.yaml"], indirect=["mocked_s3"])
@@ -96,7 +99,7 @@ def test__transfer_single_file(mocked_s3):
         "2020-01-01/collection_name.csv.gz",
     ]
 
-    assert transfer._transfer_single_file("2020-01-01/collection_name.csv.gz", mocked_s3)
+    assert transfer._transfer_single_file("2020-01-01/collection_name.csv.gz", mocked_s3) is None
     assert all([mocked_s3[idx].info(f) for idx, f in enumerate(files)])
 
 
@@ -106,27 +109,31 @@ def test__transfer_single_file_same_client(mocked_s3):
     mocked_s3[0].s3fs.touch("BUCKET/a/b.csv")
     files = ["a/b.csv", "a-copy/b.csv"]
 
-    assert transfer._transfer_single_file("a/b.csv", mocked_s3)
+    assert transfer._transfer_single_file("a/b.csv", mocked_s3) is None
     assert all([mocked_s3[idx].info(f) for idx, f in enumerate(files)])
 
 
 @pytest.mark.parametrize("mocked_s3", ["sample_config.yaml"], indirect=["mocked_s3"])
-def test__transfer_single_file_unable_to_verify(mocked_s3, mocker):
+@pytest.mark.parametrize("disable_backoff", [transfer], indirect=["disable_backoff"])
+def test__transfer_single_file_unable_to_verify(mocked_s3, disable_backoff, mocker):
     """Should return False on verification failure."""
     mocked_s3[0].s3fs.touch("DH-PLAYPEN/storage/input/2020-01-01/collection_name.csv.gz")
     mocker.patch("solgate.transfer.verify", return_value=False)
 
-    assert transfer._transfer_single_file("2020-01-01/collection_name.csv.gz", mocked_s3) is False
+    with pytest.raises(transfer.TransferFailed):
+        transfer._transfer_single_file("2020-01-01/collection_name.csv.gz", mocked_s3)
 
 
 @pytest.mark.parametrize("mocked_s3", ["sample_config.yaml"], indirect=["mocked_s3"])
-def test__transfer_single_file_fails(mocked_s3):
+@pytest.mark.parametrize("disable_backoff", [transfer], indirect=["disable_backoff"])
+def test__transfer_single_file_fails(mocked_s3, disable_backoff):
     """Should return False if unable to transfer."""
     mocked_s3[0].s3fs.touch("DH-PLAYPEN/storage/input/2020-01-01/collection_name.csv.gz")
     destination_client = mocked_s3[1]
     destination_client._S3FileSystem__base_path = "BUCKET-DOESNT-EXIST"
 
-    assert transfer._transfer_single_file("2020-01-01/collection_name.csv.gz", mocked_s3) is False
+    with pytest.raises(transfer.TransferFailed):
+        transfer._transfer_single_file("2020-01-01/collection_name.csv.gz", mocked_s3)
 
 
 @pytest.mark.parametrize("mocked_s3", ["same_client.yaml"], indirect=["mocked_s3"])

--- a/tests/transfer_test.py
+++ b/tests/transfer_test.py
@@ -8,16 +8,21 @@ from solgate.utils import S3File
 
 
 @pytest.mark.parametrize(
-    "file_list", ([dict(key="a/b/file.csv")], [dict(key="a/b/file1.csv"), dict(key="a/b/file2.csv")])
+    "file_list,dry_run",
+    (
+        ([dict(key="a/b/file.csv")], False),
+        ([dict(key="a/b/file.csv")], True),
+        ([dict(key="a/b/file1.csv"), dict(key="a/b/file2.csv")], True),
+    ),
 )
-def test_send(mocker, file_list, mocked_solgate_s3_file_system):
+def test_send(mocker, file_list, dry_run, mocked_solgate_s3_file_system):
     """Should request files to be sent to clients."""
     mocked_transfer_single_file = mocker.patch("solgate.transfer._transfer_single_file")
 
-    transfer.send(file_list, {})
+    transfer.send(file_list, {}, dry_run)
 
     for f in file_list:
-        mocked_transfer_single_file.assert_any_call(f["key"], [mocked_solgate_s3_file_system])
+        mocked_transfer_single_file.assert_any_call(f["key"], [mocked_solgate_s3_file_system], dry_run)
 
 
 @pytest.mark.parametrize(
@@ -101,6 +106,25 @@ def test__transfer_single_file(mocked_s3):
 
     assert transfer._transfer_single_file("2020-01-01/collection_name.csv.gz", mocked_s3) is None
     assert all([mocked_s3[idx].info(f) for idx, f in enumerate(files)])
+
+
+@pytest.mark.parametrize("mocked_s3", ["sample_config.yaml"], indirect=["mocked_s3"])
+def test__transfer_single_file_dry_run(mocked_s3, mocker):
+    """Should transfer and verify file."""
+    mocked_s3[0].s3fs.touch("DH-PLAYPEN/storage/input/2020-01-01/collection_name.csv.gz")
+    mocked_copy = mocker.patch("solgate.transfer.copy")
+
+    files = [
+        "collection_name/historic/2020-01-01-collection_name.csv",
+        "collection_name/latest/full_data.csv",
+        "2020-01-01/collection_name.csv.gz",
+    ]
+
+    assert transfer._transfer_single_file("2020-01-01/collection_name.csv.gz", mocked_s3, True) is None
+    mocked_copy.assert_not_called()
+    for idx, f in enumerate(files):
+        with pytest.raises(FileNotFoundError):
+            mocked_s3[idx + 1].info(f)
 
 
 @pytest.mark.parametrize("mocked_s3", ["same_client.yaml", "same_flags.yaml"], indirect=["mocked_s3"])

--- a/tests/utils/s3_test.py
+++ b/tests/utils/s3_test.py
@@ -97,9 +97,11 @@ def test_s3_file_system_copy(dest_base, result, mocked_s3):
     [
         pytest.param({}, 4, id="All CSV objects"),
         pytest.param(dict(path="folder1"), 1, id="All CSV objects in folder1"),
-        pytest.param(dict(maxdepth=1), 1, id="All objects directly in root"),
-        pytest.param(dict(maxdepth=2), 2, id="All CSV objects in root + 1st level folder"),
-        (dict(constraint=lambda m: m["LastModified"] == datetime(2020, 1, 1, tzinfo=timezone.utc)), 1),
+        pytest.param(
+            dict(constraint=lambda m: m.last_modified == datetime(2020, 1, 1, tzinfo=timezone.utc)),
+            1,
+            id="Custom timedelta",
+        ),
     ],
 )
 @pytest.mark.parametrize("mocked_s3", ["same_client.yaml"], indirect=["mocked_s3"])


### PR DESCRIPTION
- [x] Enable retry via `backoff` library
- [x] Add `--dry-run` flag to test internal logic
- [x] Improve logging
- [x] Add `--silent` flag for less verbose listing
- [x] Use `boto3` for bucket listing making it lightning fast compared to s3fs