### PR TITLE
feat: Set Koku pipeline to split on 150 files

### DIFF
--- a/manifests/overlays/prod/cost-management/cronwf.yaml
+++ b/manifests/overlays/prod/cost-management/cronwf.yaml
@@ -11,5 +11,7 @@ spec:
       parameters:
         - name: config
           value: solgate-cost-management
+        - name: split
+          value: "150"
     workflowTemplateRef:
       name: solgate


### PR DESCRIPTION
## Related Issues and Dependencies

n/a

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Koku is hitting pod deadline timeouts on sync. Let's try splitting much sooner into multiple pods.

Last sync was about 1800 files in total, let's try 150 files per worker.  