### PR TITLE
Adjust floorist timedelta to 24 hours for failsafe

### DIFF
--- a/manifests/overlays/prod/floorist/floorist.enc.yaml
+++ b/manifests/overlays/prod/floorist/floorist.enc.yaml
@@ -9,7 +9,7 @@ stringData:
         alerts_smtp_server: smtp.corp.redhat.com
         alerts_from: solgate-alerts@redhat.com
         alerts_to: insights-compliance@redhat.com
-        timedelta: 12h
+        timedelta: 24h
         source:
           endpoint_url: https://s3.amazonaws.com
           base_path: insights-metrics-export-prod


### PR DESCRIPTION
## Related Issues and Dependencies
https://github.com/aicoe-aiops/sync-pipelines/pull/123
https://issues.redhat.com/browse/APPSRE-4003

## This introduces a breaking change

- [ ] Yes
- [x] No

## Description
We're dumping data every 24 hour, but we would like to have the synchronization (not failing) in every 12. This is a failsafe setting that copies a bit more data and prevents the system from failing if there are no new dump files.

@Victoremepunto @tumido @accorvin 