### PR TITLE
chore: Report Tower analytics to datahub not to tumido

### DIFF
--- a/manifests/overlays/prod/tower-analytics-prod/secret.enc.yaml
+++ b/manifests/overlays/prod/tower-analytics-prod/secret.enc.yaml
@@ -8,7 +8,7 @@ stringData:
     config.yaml: |
         alerts_smtp_server: smtp.corp.redhat.com
         alerts_from: solgate-alerts@redhat.com
-        alerts_to: tcoufal@redhat.com
+        alerts_to: data-hub-alerts@redhat.com
 
         source:
           endpoint_url: https://s3.us-east-1.amazonaws.com
@@ -23,8 +23,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2021-04-27T10:05:22Z"
-    mac: ENC[AES256_GCM,data:bPj36Ks5fhQ4ctD9LG9YC7WxcO/VGMBdxb1lEUvkpiMo3+7TARA46XIR+jtwTC35h+xI6TZrPHeqXoKQ+SSbmQjyOTnGy+96allXD+kfcuC1dyL7g+neCYUHL5eTc+ABwVAhGKi17e87QAXbmjGqjOATkCanjPA4jW6+Ysf4bBU=,iv:NgPwhEg0RP7H6WlJRzRXm6uSkobBd0UGba94zeDG/qE=,tag:LU/km1/TqDEvDF0LmEdStA==,type:str]
+    lastmodified: "2021-12-02T11:10:14Z"
+    mac: ENC[AES256_GCM,data:cWhGQ0FWQdG0dkgDTWyr0Vbs5Ido11OhWmW/ARerY3iR34Q+OBXLVCT+x00RfKeKlEbaMXHdi3YYR1tDfqbZCruZGp2KuZy923Hzb+dU93APYXZA1Kx87KIwo5AKh7Djt6EnnjKHYBFiDENsNcYGy7W/Owlb8dreZPIRbntN4BQ=,iv:5Xb0nEBd7QbSzr5VEcrvJbyP+2txjW/HPdYzPqXFWHo=,tag:NZXN/IiDo5py0s7hYLpulw==,type:str]
     pgp:
         - created_at: "2020-12-18T11:46:34Z"
           enc: |

--- a/manifests/overlays/prod/tower-analytics-stage/secret.enc.yaml
+++ b/manifests/overlays/prod/tower-analytics-stage/secret.enc.yaml
@@ -8,7 +8,7 @@ stringData:
     config.yaml: |
         alerts_smtp_server: smtp.corp.redhat.com
         alerts_from: solgate-alerts@redhat.com
-        alerts_to: tcoufal@redhat.com
+        alerts_to: data-hub-alerts@redhat.com
 
         source:
           endpoint_url: https://s3.us-east-1.amazonaws.com
@@ -23,8 +23,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2021-04-27T10:06:53Z"
-    mac: ENC[AES256_GCM,data:1n7PJCbK4Hjw7N0Efi5wxUc78Oe5tj68aehIaY0aNmqvcypmtj2KbKQI0zertt8jIarTHlbtJslpdmbJZ3bH55iZfuJDMvafoRJOaIy9K9jHGkdvQeQGy+6ptK/45aTJvSk7/phN+ldv+hu2yiLnS2Y9U0z8SOUZ66V2+R7VgwE=,iv:vgug/RMWCqipXlC+VwAR65W43aLxCRHascki24caEU4=,tag:DlurSV41dw3NsLQjUglIlQ==,type:str]
+    lastmodified: "2021-12-02T11:10:10Z"
+    mac: ENC[AES256_GCM,data:fTNs2PAYAP0mBhwaNA2weH2L3bLFlRG2jSIJtBuOW/l4c8RwEFOxNjS9XDP68pUunYLYklLH0imKXWZ4S1zpwRYeK4zkfdRruvmJTbvsiuOLTIAlhw+MYbfprhxuMNHYkewDcVywZ6y4pPzVTfrvYALLB4S6s4DldkvZljen908=,iv:vMH00Rc5ODLVWsyZVcS5yU9fPj32ZcBjUeEh3wI9+kk=,tag:j24CUUKk6FM0fGfqAQnifg==,type:str]
     pgp:
         - created_at: "2020-12-18T11:46:34Z"
           enc: |


### PR DESCRIPTION
Change `tower-*` pipelines config to report to idh alerts instead of tumido.