### PR TITLE
Update copy function to use boto3

### DIFF
--- a/solgate/transfer.py
+++ b/solgate/transfer.py
@@ -27,7 +27,7 @@ def copy(files: List[S3File]) -> None:
         log_args = dict(source=dict(client=a.client, key=a.key), destination=dict(client=b.client, key=b.key))
         if a.client == b.client:
             logger.info("Copying within the same clients", log_args)
-            a.client.copy(a.key, b.key)
+            a.client.copy(a.client.bucket, a.key, b.client.bucket, b.key)
             continue
 
         logger.info("Copying to a different client", log_args)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,9 +24,14 @@ def mocked_s3(fixture_dir, request):
         for instance in s3fs_instances:
             instance.s3fs = s3fs.S3FileSystem(key=instance.aws_access_key_id, secret=instance.aws_secret_access_key)
             instance.s3fs.s3.create_bucket(Bucket=instance._S3FileSystem__base_path.split("/")[0])
-            instance.boto3 = boto3.resource(
+            instance.s3_client = boto3.resource(
                 "s3", aws_access_key_id=instance.aws_access_key_id, aws_secret_access_key=instance.aws_secret_access_key
-            ).Bucket(instance._S3FileSystem__base_path.split("/")[0])
+            )
+            instance.s3c = boto3.client(
+                "s3", aws_access_key_id=instance.aws_access_key_id, aws_secret_access_key=instance.aws_secret_access_key
+            )
+            instance.boto3 = instance.s3_client.Bucket(instance._S3FileSystem__base_path.split("/")[0])
+            instance.s3_client.create_bucket(Bucket=instance._S3FileSystem__base_path.split("/")[0])
         yield s3fs_instances
 
 

--- a/tests/transfer_test.py
+++ b/tests/transfer_test.py
@@ -134,7 +134,7 @@ def test__transfer_single_file_dry_run(mocked_s3, mocker):
 @pytest.mark.parametrize("mocked_s3", ["same_client.yaml", "same_flags.yaml"], indirect=["mocked_s3"])
 def test__transfer_single_file_same_client(mocked_s3):
     """Should transfer faster between the same clients."""
-    mocked_s3[0].s3fs.touch("BUCKET/a/b.csv")
+    mocked_s3[0].s3c.put_object(Bucket='BUCKET', Key='a/b.csv', Body='foo')
     files = ["a/b.csv", "a-copy/b.csv"]
 
     assert transfer._transfer_single_file("a/b.csv", mocked_s3, 1, 1) is None
@@ -167,14 +167,14 @@ def test__transfer_single_file_fails(mocked_s3, disable_backoff):
 @pytest.mark.parametrize("mocked_s3", ["same_client.yaml"], indirect=["mocked_s3"])
 def test_copy_same_client(mocked_s3, mocker):
     """Should use client.copy when the clients are the same."""
-    mocked_s3[0].s3fs.touch("BUCKET/a/b.csv")
+    mocked_s3[0].s3c.put_object(Bucket='BUCKET', Key='a/b.csv', Body='foo')
     spies_copy = [mocker.spy(client, "copy") for client in mocked_s3]
     spies_open = [mocker.spy(client, "open") for client in mocked_s3]
 
     transfer.copy([S3File(client, "a/b.csv") for client in mocked_s3])
 
     [spy.assert_not_called() for spy in spies_open]
-    spies_copy[0].assert_called_once_with("a/b.csv", "a/b.csv")
+    spies_copy[0].assert_called_once_with("BUCKET", "a/b.csv", "BUCKET", "a/b.csv")
     spies_copy[1].assert_not_called()
 
 

--- a/tests/utils/s3_test.py
+++ b/tests/utils/s3_test.py
@@ -75,21 +75,21 @@ def test_s3_file_system_str():
 
 
 @pytest.mark.parametrize(
-    "dest_base,result",
+    "dest_key,result",
     [
-        (None, "BUCKET/c/d.csv"),
-        ("BUCKET/different_base", "BUCKET/different_base/c/d.csv"),
-        ("BUCKET/base_with_slash/", "BUCKET/base_with_slash/c/d.csv"),
+        (None, "a/b.csv"),
+        ("", "a/b.csv"),
+        ("c/d.csv", "c/d.csv")
     ],
 )
 @pytest.mark.parametrize("mocked_s3", ["same_client.yaml"], indirect=["mocked_s3"])
-def test_s3_file_system_copy(dest_base, result, mocked_s3):
+def test_s3_file_system_copy(dest_key, result, mocked_s3):
     """Should copy within the same S3fs."""
     fs = mocked_s3[0]
-    fs.s3fs.touch("BUCKET/a/b.csv")
-    fs.copy("a/b.csv", "c/d.csv", dest_base)
+    fs.s3c.put_object(Bucket='BUCKET', Key='a/b.csv', Body='foo')
+    fs.copy("BUCKET", "a/b.csv", "BUCKET", dest_key)
 
-    assert fs.s3fs.find(result)
+    assert fs.s3c.get_object(Bucket='BUCKET', Key=result)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The s3fs copy function was attemting to use a multipart upload to copy,
which was failing. Switching to boto3 resolves this issue.
