### PR TITLE
Add configurable ability for workflows to skip (instead of alert) when no new files available to sync.

### DIFF
--- a/manifests/overlays/prod/rhods-usage-metrics-dev/secret.enc.yaml
+++ b/manifests/overlays/prod/rhods-usage-metrics-dev/secret.enc.yaml
@@ -17,12 +17,16 @@ stringData:
         destinations:
           - endpoint_url: https://s3.upshift.redhat.com
             base_path: DH-SECURE-RHODS-USAGE-METRICS-DEV
+
+        ignore_alerts:
+          - no_files
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
-    lastmodified: '2022-02-23T20:06:36Z'
-    mac: ENC[AES256_GCM,data:WHy9dMxzvIq5XPzAXiRc4oo/GgZnEQvFx8AH8nsaVQYyOJUhgMl4HPdPsbDiuKPQK05YRRI/hO9nOS9y81+FQbOWTaxFKq+FOAfdM+I1EA6GKNIZI5LR3Rs+7JzpQfEy8GIcXaXlSiwgYUiBhFuJMffzWlYJ2Q4F9+MQOaf2jEQ=,iv:yFFZ3Vp3SxdCJh89XJPLBlNyNSMpF6if1MR73r1RHXs=,tag:owntyVdOvMYDsH3yTYXKZg==,type:str]
+    hc_vault: []
+    lastmodified: '2022-04-08T23:23:13Z'
+    mac: ENC[AES256_GCM,data:ZHobL8IIy5wO32eiLyDOUrti54/L04tyxaoT0fJWb90LRs+GDvslZfsRqOXm8xnWbpJR/SPQVwJsvRzvWuUyxqZjxlaQ+LGVcRpqFo5AA82rboeZay1M+cDezVrwkIQ279YZLDNsCNzw1NGY1vtqy/QHzfm84N3v3sSr5cotxp0=,iv:xNmPD21dWqz7iHO3yHs/h44n/KDkBCH1fNquNEaMc/U=,tag:WwSe1bhQv3J6RVqjlMe+eA==,type:str]
     pgp:
     -   created_at: '2020-12-18T11:46:15Z'
         enc: |

--- a/solgate/cli.py
+++ b/solgate/cli.py
@@ -6,7 +6,8 @@ from pathlib import Path
 import click
 
 from solgate import list_source, send, send_report, __version__ as version
-from .utils import serialize, logger, deserialize, read_general_config, NoFilesToSyncError, FilesFailedToSyncError
+from .utils import serialize, logger, deserialize, read_general_config, initialize_file
+from .utils import NoFilesToSyncError, FilesFailedToSyncError
 from .report import DEFAULT_RECIPIENT, DEFAULT_SENDER, DEFAULT_SMTP_SERVER
 
 
@@ -103,8 +104,10 @@ def _list(ctx, backfill: bool, silent: bool = False, output: str = None):
     if backfill:
         logger.info("Running in a backfill mode")
     try:
+        idx = 0
+        initialize_file(output)
         for idx, file in enumerate(list_source(ctx.obj["config"], backfill), start=1):
-            if output:
+            if output and file is not None:
                 serialize(file, output)
             if not silent:
                 click.echo(file)

--- a/solgate/utils/__init__.py
+++ b/solgate/utils/__init__.py
@@ -2,7 +2,7 @@
 
 # flake8: noqa
 
-from .io import deserialize, key_formatter, read_general_config, serialize
+from .io import deserialize, key_formatter, read_general_config, serialize, initialize_file
 from .logging import logger
 from .s3 import S3File, S3FileSystem, S3ConfigSelector
 from .exceptions import EXIT_CODES, NoFilesToSyncError, FilesFailedToSyncError

--- a/solgate/utils/io.py
+++ b/solgate/utils/io.py
@@ -73,6 +73,17 @@ def deserialize(filename: str) -> Any:
     return gen(), len(open(filename).readlines())
 
 
+def initialize_file(filename: str) -> None:
+    """Writes an empty file
+
+    Args:
+        filename (str): File name or path.
+
+    """
+    with open(filename, "w") as f:
+        pass
+
+
 def _read_yaml_file(filename: Union[str, Path]) -> Dict[str, Any]:
     """Read a file.
 

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -40,11 +40,13 @@ def test_list(run, mocker, cli_args, func_args, file_output):
     """Should call proper functions on list command."""
     mocked_list_source = mocker.patch("solgate.cli.list_source", return_value=["list", "of", "files"])
     mocked_serialize = mocker.patch("solgate.cli.serialize")
+    mocked_initialize_file = mocker.patch("solgate.cli.initialize_file")
 
     result = run(cli_args)
 
     assert result.exit_code == 0
     mocked_list_source.assert_called_once_with(*func_args)
+    mocked_initialize_file.assert_called_once()
 
     if file_output:
         calls = [mocker.call(f, "output.json") for f in ("list", "of", "files")]
@@ -60,6 +62,7 @@ def test_list(run, mocker, cli_args, func_args, file_output):
 def test_list_negative(run, mocker, side_effect, errno):
     """Should fail on list command."""
     mocker.patch("solgate.cli.list_source", side_effect=side_effect)
+    mocker.patch("solgate.cli.initialize_file")
 
     result = run("list")
 

--- a/tests/utils/io_test.py
+++ b/tests/utils/io_test.py
@@ -230,6 +230,16 @@ def test_serialize(mocker):
     args = "".join(c.args[0] for c in calls)
     assert args == '{"a": "b"}\n'
 
+def test_ititialize_file(mocker):
+    """Should serialize to JSON."""
+    mocked_open = mocker.patch("builtins.open")
+    io.initialize_file("file.json")
+
+    mocked_open.assert_called_once_with("file.json", "w")
+    calls = mocked_open.return_value.__enter__.return_value.write.call_args_list
+    args = "".join(c.args[0] for c in calls)
+    assert args == ''
+
 
 @pytest.mark.parametrize(
     "input,output",


### PR DESCRIPTION
## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Implements the ability to disable, from config, a workflow's failures/alerts caused by a bucket simply not having new files to sync within its given TIMEDELTA

## Description

Implements the ability to disable the NoFilesToSyncError on `solgate list`, which causes the entire pipeline to fail if encountered
The rest of the Argo Workflow happens to already handle this well (will skip the sync step if no json files to act on) and this allows per-workflow configuration to reduce alert fatigue stemming from low-traffic buckets

Also adds this new configuration item to the wf def for the dh-rhods-usage-metrics-dev sync pipeline, whose constant alert emails inspired this PR :)
